### PR TITLE
cambio ruta 404

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -3,7 +3,7 @@
 <html>
 
 <head>
-    <meta http-equiv="refresh" content="0; url=/04-WebApp-Prehistoria/" />
+    <meta http-equiv="refresh" content="0; url=/#/" />
 </head>
 
 <body></body>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,7 +7,7 @@ import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <HashRouter>  
+    <HashRouter>
       <App />
     </HashRouter>
   </React.StrictMode>


### PR DESCRIPTION
Cuando GitHub Pages no encuentra una ruta (/04-WebApp-Prehistoria/), carga 404.html.
Y como esta redirige automáticamente a /#/, tu SPA cargará correctamente la primera pantalla (ModoJuego) siempre.